### PR TITLE
fix: update YTS API base to working endpoint

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -75,7 +75,7 @@ function navFooter(): string {
 
 // --- API Layer ---
 
-const API_BASE = "https://yts.torrentbay.st/api/v2";
+const API_BASE = "https://movies-api.accel.li/api/v2";
 const DOWNLOAD_DIR = join(homedir(), "Downloads", "Movizone");
 const STATE_DIR = join(DOWNLOAD_DIR, ".downloads");
 


### PR DESCRIPTION
## Problem

The CLI's menu renders fine, but every data-fetching action (Search / Browse / Trending / Top rated) returns nothing. Root cause is the API base URL:

\`\`\`
index.ts:78  const API_BASE = "https://yts.torrentbay.st/api/v2";
\`\`\`

That domain is now behind a Cloudflare challenge and responds with **HTTP 403** and a "Just a moment..." HTML page instead of JSON, so \`apiGet()\` fails.

## Fix

Point \`API_BASE\` at the announced new base, \`https://movies-api.accel.li/api/v2\` (the old mirror's response body even states *"Base URL moving to https://movies-api.accel.li/api/v2/"*).

Verified against the endpoints the app uses:
- \`list_movies.json\` → HTTP 200, valid JSON
- \`movie_details.json\` → HTTP 200, valid JSON

Subtitles (\`yts-subs.com\`) and download paths use separate domains and are unaffected.

## Testing
- \`bun test\` → 45 pass, 0 fail
- Smoke-tested both endpoints live

🤖 Generated with [Claude Code](https://claude.com/claude-code)